### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ page_type: sample
 description: This sample demonstrates how to use the Microsoft Graph .NET SDK to implement a custom search connector.
 products:
 - ms-graph
-- microsoft-graph-connectors-api
 - microsoft-search
 languages:
 - csharp


### PR DESCRIPTION
`microsoft-graph-connectors-api` taxonomy slug has been deprecated. It was replaced with `ms-graph`